### PR TITLE
feat: Java21版本支持

### DIFF
--- a/arouter-gradle-plugin/build.gradle.kts
+++ b/arouter-gradle-plugin/build.gradle.kts
@@ -2,7 +2,7 @@
 
 plugins {
     id("java-gradle-plugin")
-    id("org.jetbrains.kotlin.jvm") version "1.8.20"
+    id("org.jetbrains.kotlin.jvm") version "1.9.23"
     id("com.gradle.plugin-publish") version "1.2.0"
 }
 
@@ -14,7 +14,7 @@ repositories {
 
 // The project version will be used as your plugin version when publishing.
 group = "io.github.JailedBird"
-version = "1.0.2"
+version = "1.0.3-java21"
 
 //pluginBundle {
 //    vcsUrl = "https://github.com/JailedBird/ArouterGradlePlugin"
@@ -28,8 +28,8 @@ gradlePlugin {
         register("ARouterPlugin") {
             id = "io.github.JailedBird.ARouterPlugin"
             implementationClass = "cn.jailedbird.arouter_gradle_plugin.ARouterPlugin"
-            displayName = "Arouter AGP7.4+ plugin"
-            description = "Arouter AGP7.4+ plugin"
+            displayName = "Arouter AGP7.4+ plugin with Java 21 support"
+            description = "Arouter AGP7.4+ plugin with Java 21 support (ASM 9.7)"
         }
     }
 }
@@ -58,9 +58,10 @@ gradlePlugin {
 dependencies {
     implementation(kotlin("stdlib"))
     gradleApi()
-    compileOnly("com.android.tools.build:gradle:7.4.0")
+    compileOnly("com.android.tools.build:gradle:8.2.2")
     compileOnly("commons-io:commons-io:2.8.0")
     compileOnly("commons-codec:commons-codec:1.15")
-    compileOnly("org.ow2.asm:asm-commons:9.4")
-    compileOnly("org.ow2.asm:asm-tree:9.4")
+    // 升级 ASM 到 9.7 支持 Java 21 (class file version 65)
+    compileOnly("org.ow2.asm:asm-commons:9.7")
+    compileOnly("org.ow2.asm:asm-tree:9.7")
 }

--- a/arouter-gradle-plugin/src/main/java/cn/jailedbird/arouter_gradle_plugin/utils/InjectUtils.kt
+++ b/arouter-gradle-plugin/src/main/java/cn/jailedbird/arouter_gradle_plugin/utils/InjectUtils.kt
@@ -19,7 +19,7 @@ object InjectUtils {
         // Fix: https://github.com/JailedBird/ArouterGradlePlugin/issues/4
         // Resolution: https://github.com/didi/DroidAssist/issues/38#issuecomment-1080378515
         val cw = ClassWriter(cr, ClassWriter.COMPUTE_FRAMES)
-        val cv = InjectClassVisitor(Opcodes.ASM7, cw, targetList)
+        val cv = InjectClassVisitor(Opcodes.ASM9, cw, targetList)
         cr.accept(cv, ClassReader.EXPAND_FRAMES)
         return cw.toByteArray()
     }
@@ -51,7 +51,7 @@ object InjectUtils {
             var mv = super.visitMethod(access, name, desc, signature, exceptions)
             // generate code into this method
             if (name == ScanSetting.GENERATE_TO_METHOD_NAME) {
-                mv = RouteMethodVisitor(Opcodes.ASM7, mv, targetList)
+                mv = RouteMethodVisitor(Opcodes.ASM9, mv, targetList)
             }
             return mv
         }

--- a/arouter-gradle-plugin/src/main/java/cn/jailedbird/arouter_gradle_plugin/utils/ScanUtils.kt
+++ b/arouter-gradle-plugin/src/main/java/cn/jailedbird/arouter_gradle_plugin/utils/ScanUtils.kt
@@ -55,7 +55,7 @@ object ScanUtils {
     ) {
         val cr = ClassReader(inputStream)
         val cw = ClassWriter(cr, 0)
-        val cv = ScanClassVisitor(Opcodes.ASM7, cw, targetList)
+        val cv = ScanClassVisitor(Opcodes.ASM9, cw, targetList)
         cr.accept(cv, ClassReader.EXPAND_FRAMES)
         if (autoClose) {
             inputStream.close()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id ("com.android.application") version "8.1.0" apply false
-    id ("com.android.library") version "8.1.0" apply false
-    id ("org.jetbrains.kotlin.android") version "1.8.20" apply false
-    id ("org.jetbrains.kotlin.jvm") version "1.8.20" apply false
-    id ("com.google.devtools.ksp") version "1.8.20-1.0.10" apply false
+    id ("com.android.application") version "8.2.2" apply false
+    id ("com.android.library") version "8.2.2" apply false
+    id ("org.jetbrains.kotlin.android") version "1.9.23" apply false
+    id ("org.jetbrains.kotlin.jvm") version "1.9.23" apply false
+    id ("com.google.devtools.ksp") version "1.9.23-1.0.20" apply false
 }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,3 @@
 # https://github.com/jitpack/jitpack.io/issues/4474
 jdk:
-  - openjdk11
+  - openjdk17


### PR DESCRIPTION
问题描述：当项目中有代码是Java21版本的class文件时，其编译无法通过。报错：Unsupported class file major version 65

根因定位：其通过ASM库读写 .class 文件，ASM7不支持Java21

解决方案：升级到 ASM 9.7 后，就能正确解析 Java 21 的 class 文件头了，同时也兼容旧版本的 class 文件。