### PR TITLE
fix: ARouterConfig 开启后未生效

### DIFF
--- a/arouter-gradle-plugin/src/main/java/cn/jailedbird/arouter_gradle_plugin/ARouterPlugin.kt
+++ b/arouter-gradle-plugin/src/main/java/cn/jailedbird/arouter_gradle_plugin/ARouterPlugin.kt
@@ -22,14 +22,19 @@ class ARouterPlugin : Plugin<Project> {
                 project.extensions.getByType(AndroidComponentsExtension::class.java)
 
             androidComponents.onVariants { variant ->
-                val disableDebugTransform =
-                    project.extensions.getByType(ARouterConfig::class.java).disableTransformWhenDebugBuild
+                val config = project.extensions.getByType(ARouterConfig::class.java)
 
-                if (disableDebugTransform && variant.name.contains("debug")) {
-                    println("Skip ARouter Transform When Debug Build!")
+                // 完全禁用 Transform
+                if (config.disableTransform) {
+                    println("Skip ARouter Transform! (disableTransform=true) variant=${variant.name}")
                     return@onVariants
                 }
 
+                // 仅 Debug 构建时禁用
+                if (config.disableTransformWhenDebugBuild && variant.name.contains("debug", ignoreCase = true)) {
+                    println("Skip ARouter Transform When Debug Build! variant=${variant.name}")
+                    return@onVariants
+                }
                 val taskProviderTransformAllClassesTask =
                     project.tasks.register(
                         "${variant.name}TransformAllClassesTask",

--- a/arouter-gradle-plugin/src/main/java/cn/jailedbird/arouter_gradle_plugin/ArouterConfig.kt
+++ b/arouter-gradle-plugin/src/main/java/cn/jailedbird/arouter_gradle_plugin/ArouterConfig.kt
@@ -1,5 +1,9 @@
 package cn.jailedbird.arouter_gradle_plugin
 
 open class ARouterConfig {
+    /** 仅在 Debug 构建时禁用 Transform（Release 仍会执行） */
     var disableTransformWhenDebugBuild: Boolean = false
+
+    /** 完全禁用 Transform（所有构建类型都不执行） */
+    var disableTransform: Boolean = false
 }


### PR DESCRIPTION
问题描述：
// 添加这个配置块
arouter_config {
disableTransformWhenDebugBuild = true
}
但是并没有生效，还是执行Task :a_commonCommonDebugTransformAllClassesTask

根因定位：ARouterPlugin.kt第28行采用的是精准匹配"debug"，而当前Variants通常采用常见的驼峰命名法，如：a_commonCommonDebug等。

解决方案：配置ignoreCase = true：variant.name.contains("debug", ignoreCase = true)